### PR TITLE
fix(api): :bug: fix thumbnail mapping

### DIFF
--- a/apps/api/lib/response/iiif/constructManifest.js
+++ b/apps/api/lib/response/iiif/constructManifest.js
@@ -28,7 +28,7 @@ export async function constructManifest(data, API) {
     ],
     thumbnail: [
       {
-        id: data.thumbnail.value ?? data.thumbnail,
+        id: data.thumbnail['@value' ?? 'value'] ?? data.thumbnail,
         type: "Image",
         format: "image/jpeg",
         width: 250,


### PR DESCRIPTION
Thumbnail mapping broke after changing the context from 'value' to use default '@value', this fixes the error