### PR TITLE
fix(tp): pass matching as list to fetch data

### DIFF
--- a/apps/sps-termportal-web/pages/search.vue
+++ b/apps/sps-termportal-web/pages/search.vue
@@ -106,7 +106,7 @@ const fetchFurtherSearchData = () => {
       useFetchSearchData(
         useGenSearchOptions("further", {
           offset,
-          matching: Object.keys(offset),
+          matching: [Object.keys(offset)],
         })
       );
     }


### PR DESCRIPTION
Further fetching didn't work because matching pattern was passed as string and not as a list.

## Fix
Pass list when generating search options for further feteching