### PR TITLE
Fix #tp fix matching filter display

### DIFF
--- a/apps/sps-termportal-web/composables/useGenSearchOptions.ts
+++ b/apps/sps-termportal-web/composables/useGenSearchOptions.ts
@@ -1,5 +1,4 @@
 import { SearchOptions } from "~~/utils/vars";
-import { Samling } from "~/utils/vars-termbase";
 
 export default function (situation: string, options?: SearchOptions) {
   const searchInterface = useSearchInterface();
@@ -38,6 +37,11 @@ export default function (situation: string, options?: SearchOptions) {
     }
     if (searchFilterData.value.matching.length > 0) {
       newOptions.matching = searchFilterData.value.matching.map((e) => [e]);
+    }
+    // Check if flattened array includes "full"
+    // Happens when filter is used
+    if (newOptions.matching.flat().includes("full")) {
+      newOptions.matching.splice(0, 1, ["full-cs", "full-ci"]);
     }
   }
   if (options) {

--- a/apps/sps-termportal-web/locales/en.json
+++ b/apps/sps-termportal-web/locales/en.json
@@ -60,6 +60,7 @@
       "hiddenLabel": "Deprecated term"
     },
     "matching": {
+      "full": "exact",
       "full-cs": "exact",
       "full-ci": "exact",
       "startsWith-ci": "starts with",

--- a/apps/sps-termportal-web/locales/nb.json
+++ b/apps/sps-termportal-web/locales/nb.json
@@ -60,6 +60,7 @@
       "hiddenLabel": "Frarådet term"
     },
     "matching": {
+      "full": "nøyaktig",
       "full-cs": "nøyaktig",
       "full-ci": "nøyaktig",
       "startsWith-ci": "starter med",

--- a/apps/sps-termportal-web/locales/nn.json
+++ b/apps/sps-termportal-web/locales/nn.json
@@ -61,6 +61,7 @@
       "hiddenLabel": "Frårådd term"
     },
     "matching": {
+      "full": "nøyaktig",
       "full-cs": "nøyaktig",
       "full-ci": "nøyaktig",
       "startsWith-ci": "startar med",

--- a/apps/sps-termportal-web/server/api/search/suggest.ts
+++ b/apps/sps-termportal-web/server/api/search/suggest.ts
@@ -9,7 +9,6 @@ export default defineEventHandler(async (event) => {
     runtimeConfig.public.base
   );
 
-  console.log(query)
   const controller = new AbortController();
   const timer = setTimeout(() => {
     controller.abort();
@@ -30,6 +29,6 @@ export default defineEventHandler(async (event) => {
       return value;
     });
 
-    return data.results.bindings.map((binding: any) => binding.lit.value + " " + binding.sc.value);
+    return data.results.bindings.map((binding: any) => binding.lit.value);
   } catch (e) {}
 });

--- a/apps/sps-termportal-web/server/utils/parseAggregateData.ts
+++ b/apps/sps-termportal-web/server/utils/parseAggregateData.ts
@@ -1,6 +1,6 @@
 import { LabelPredicate, Matching } from "../../utils/vars";
-import { LangCode } from "../../utils/vars-language";
 import { Samling } from "../../utils/vars-termbase";
+import { LangCode } from "~/composables/locale";
 import { SearchDataStats } from "~~/composables/states";
 
 type AggregateKeys = LangCode | Samling | LabelPredicate | Matching;
@@ -15,10 +15,19 @@ export default function (
   }
 ) {
   const category = Object.keys(subObj)[0];
-  return {
+  const parsed = {
     ...obj,
     ...{
       [category]: JSON.parse(Object.values(subObj)[0].value),
     },
   };
+  // Frontend shouldn't display distinction between cs and ci.
+  // Combine them to "full"
+  if (parsed?.matching?.["full-cs"] || parsed?.matching?.["full-ci"]) {
+    const count = (parsed?.matching?.["full-cs"] || 0) + (parsed?.matching?.["full-ci"] || 0)
+    parsed.matching.full = count
+    delete parsed.matching["full-cs"]
+    delete parsed.matching["full-ci"]
+  }
+  return parsed;
 }

--- a/apps/sps-termportal-web/utils/vars.ts
+++ b/apps/sps-termportal-web/utils/vars.ts
@@ -6,6 +6,7 @@ export type SearchQueryType = "entries" | "aggregate";
 
 export type LabelPredicate = "prefLabel" | "altLabel" | "hiddenLabel";
 export type Matching =
+  | "full"
   | "full-cs"
   | "full-ci"
   | "startsWith-ci"
@@ -25,8 +26,7 @@ export const predicateOrder: LabelPredicate[] = [
   "hiddenLabel",
 ];
 export const matchingOrder: Matching[] | Matching[][] = [
-  "full-cs",
-  "full-ci",
+  "full",
   "startsWith-ci",
   "endsWith-ci",
   "subWord-ci",


### PR DESCRIPTION
We decided not to make a distinction between case sensitive and case insensitive for full matching in the results filter.

Relevance ordering should still respect case.

## Changes
- parse returned aggregate data to sum up cs and ci values
- when generating search options, full needs to be replaced with proper full-cs/ci values