### PR TITLE
fix(tp): search handling of dot before space

### DIFF
--- a/apps/sps-termportal-web/server/utils/genSearchQuery.ts
+++ b/apps/sps-termportal-web/server/utils/genSearchQuery.ts
@@ -38,6 +38,7 @@ export function sanitizeTerm(term: string) {
   return term
     .replace(/-|\(|\)|<|>|\[|\]|\/|,\s*$|\*|~|'|"|_/g, " ")
     .replace(/\s\s+/g, " ")
+    .replace(/. /g, " ")
     .trim();
 }
 


### PR DESCRIPTION
Tmp. fix for `.` before space.

Trips wildcard matching etc.
Should be properly handled in new layout with different highlighting