### PR TITLE
Fix #tp set topdomains tb fetching

### DIFF
--- a/apps/sps-termportal-web/app.vue
+++ b/apps/sps-termportal-web/app.vue
@@ -29,7 +29,7 @@ if (process.client) {
       {
         src: "/mathjax-config.js",
         type: "text/javascript",
-        defer: true
+        defer: true,
       },
       {
         id: "MathJax-script",
@@ -54,12 +54,15 @@ onMounted(() => {
   */
   $fetch("/api/domain", { retry: 1 }).then((data) => {
     for (const domain in domainData.value) {
-      domainData.value[domain].subdomains = parseRelationsRecursively(
-        data,
-        domain,
-        "narrower",
-        "subdomains"
-      );
+      // allow deactivation of topdomains on frontend that are defined in the CMS. See domain states
+      try {
+        domainData.value[domain].subdomains = parseRelationsRecursively(
+          data,
+          domain,
+          "narrower",
+          "subdomains"
+        );
+      } catch (entry) {}
     }
   });
 

--- a/apps/sps-termportal-web/components/HeaderSearchDomains.vue
+++ b/apps/sps-termportal-web/components/HeaderSearchDomains.vue
@@ -1,7 +1,7 @@
 <template>
   <div ref="wrapper">
-    <div ref="topWrapper" class="flex gap-x-2 flex-wrap md:flex-nowrap">
-      <div class="flex lg:flex-nowrap flex-wrap gap-x-1 gap-y-1">
+    <div ref="topWrapper" class="flex flex-wrap gap-x-2 md:flex-nowrap">
+      <div class="flex flex-wrap gap-x-1 gap-y-1 lg:flex-nowrap">
         <div
           v-for="domain in Object.keys(domainData)"
           :key="domain"
@@ -62,8 +62,11 @@
         <Icon
           name="mdi:chevron-down"
           size="2.2em"
-          class="ml-[-8px] mr-[-8px] text-gray-600 group-hover:text-gray-900"
-          :class="{ 'text-gray-400 group-hover:text-gray-400 ': noDomain }"
+          class="ml-[-8px] mr-[-8px] text-gray-600"
+          :class="{
+            'text-gray-400 ': noDomain,
+            'group-hover:text-gray-900': !noDomain,
+          }"
           aria-hidden="true"
         />
       </button>

--- a/apps/sps-termportal-web/components/SearchFilter.vue
+++ b/apps/sps-termportal-web/components/SearchFilter.vue
@@ -2,7 +2,7 @@
   <section
     v-if="showSearchFilter"
     id="filterCard"
-    class="h-full xl:border-r border-gray-300 pr-1 xl:pt-12"
+    class="h-full border-gray-300 pr-1 xl:border-r xl:pt-12"
   >
     <h2 class="pb-2 pt-1 text-2xl">{{ $t("searchFilter.filter") }}</h2>
     <div

--- a/apps/sps-termportal-web/components/SearchFilter.vue
+++ b/apps/sps-termportal-web/components/SearchFilter.vue
@@ -44,7 +44,7 @@
         :key="title"
       >
         <SearchFilterFieldset
-          v-if="displaySection(key)"
+          v-if="displaySection(key, data)"
           :title="title"
           :fkey="key"
         >
@@ -61,11 +61,14 @@ const searchDataStats = useSearchDataStats();
 const localeLangOrder = useLocaleLangOrder();
 const searchInterface = useSearchInterface();
 
-const displaySection = (key) => {
-  if (key === "lang" && searchInterface.value.language !== "all") {
-    return false;
+const displaySection = (key, data) => {
+  if (key === "lang") {
+    return searchInterface.value.language === "all"
+  } else if (key === "matching") {
+    return !data.length === 0;
   } else {
     return true;
   }
+
 };
 </script>

--- a/apps/sps-termportal-web/composables/states.ts
+++ b/apps/sps-termportal-web/composables/states.ts
@@ -51,7 +51,7 @@ export const useDomainData = () =>
     "DOMENE-3AHumaniora": { bases: ["LINGVISTIKK", "SEMANTIKK"] },
     "DOMENE-3AOkonomiAdministrasjon": { bases: ["NHH", "FBK", "UHR"] },
     "DOMENE-3ASamfunnsfag": { bases: ["BIBINF", "NOJU", "TOLKING"] },
-    "DOMENE-3AHelse_og_sosial": { bases: ["KUNNBP"] },
+//    "DOMENE-3AHelse_og_sosial": { bases: ["KUNNBP"] },
   }));
 
 export const useSearchInterface = () =>

--- a/apps/sps-termportal-web/pages/search.vue
+++ b/apps/sps-termportal-web/pages/search.vue
@@ -54,7 +54,7 @@ const searchterm = useSearchterm();
 const searchInterface = useSearchInterface();
 const count = computed(() => {
   try {
-    return sum(Object.values(searchDataStats.value?.matching || [])) || 0;
+    return sum(Object.values(searchDataStats.value?.context || [])) || 0;
   } catch (e) {
     return 0;
   }


### PR DESCRIPTION
- catch error when topdomains are not consistent between CMS and frontend
- fix bug when fetching further data with 'all' matching pattern
- don't display filter options when superfluous