### PR TITLE
Fix routing issue with slashes in pagenames

### DIFF
--- a/apps/sps-termportal-web/server/utils/processBinding.ts
+++ b/apps/sps-termportal-web/server/utils/processBinding.ts
@@ -21,6 +21,7 @@ export default function (binding: { [key: string]: any }): SearchDataEntry {
   if (!Object.keys(termbaseUriPatterns).includes(samling)) {
     link = binding.uri.value
       .replace(runtimeConfig.public.base, "")
+      .replace("/", "%2F") // Slashes are allowd in wiki pagenames, but cause problems with routing
       .replace("-3A", "/");
   } else {
     const patterns =

--- a/apps/sps-termportal-web/utils/utils.ts
+++ b/apps/sps-termportal-web/utils/utils.ts
@@ -96,7 +96,10 @@ export function getRelationData(
         try {
           // Pass concept object
           const label = getConceptDisplaytitle(data[target]);
-          const link = "/" + target.replace("-3A", "/");
+          // Slashed are allowed on Pagenames, should be escaped
+          // TODO might break links between concepts of external tbs
+          // Termbase is part of URI (seperated by '-3A')
+          const link = "/" + target.replace("/", "%2F").replace("-3A", "/");
           // Don't return links with no label -> linked concept doesn't exist
           if (label) {
             return [label, link];


### PR DESCRIPTION
- some characters are legal in pagenames that are note URL-safe
- "/" causes router problems