### PR TITLE
Fix #tp handling of multiple vals for lit string

### DIFF
--- a/apps/sps-termportal-web/components/TermDescription.vue
+++ b/apps/sps-termportal-web/components/TermDescription.vue
@@ -46,7 +46,7 @@
         <dd class="max-w-prose" v-html="d.subject[0]" />
       </TermProp>
       <TermProp
-        v-if="d?.['skosp:dctSource'] || d.source"
+        v-if="d?.['skosp:dctSource'] || d.source?.label"
         :label="$t('id.referanse')"
       >
         <dd

--- a/apps/sps-termportal-web/components/TermDescription.vue
+++ b/apps/sps-termportal-web/components/TermDescription.vue
@@ -109,11 +109,11 @@ const mainValue = (data) => {
     case "definition":
       return data?.label["@value"];
     case "prefLabel":
-      return data?.literalForm["@value"];
+      return data?.["@value"];
     case "altLabel":
-      return data?.literalForm["@value"];
+      return data?.["@value"];
     case "hiddenLabel":
-      return data?.literalForm["@value"];
+      return data?.["@value"];
     case "context":
       return data?.label["@value"];
     case "link":

--- a/apps/sps-termportal-web/server/utils/frameData.ts
+++ b/apps/sps-termportal-web/server/utils/frameData.ts
@@ -23,7 +23,7 @@ export default function (
       dcat: "http://www.w3.org/ns/dcat#",
       xsd: "http://www.w3.org/2001/XMLSchema#",
       vcard: "http://www.w3.org/2006/vcard/ns#",
-      literalForm: { "@id": "skosxl:literalForm" },
+      literalForm: { "@id": "skosxl:literalForm", "@container": "@set" },
       label: "rdfs:label",
       modified: "dct:modified",
       identifier: "dct:identifier",

--- a/apps/sps-termportal-web/server/utils/parseConceptData.ts
+++ b/apps/sps-termportal-web/server/utils/parseConceptData.ts
@@ -92,25 +92,29 @@ function updateLabel2(data: any, conceptUri: string, labelType: string) {
       labelType === "hasUsage"
     ) {
       language = label.label["@language"];
+      addLabel(newLabels, label, language);
     } else if (labelType === "description") {
       // TODO deprecated?
       language = label["@language"];
+      addLabel(newLabels, label, language);
     } else {
-      language = label.literalForm["@language"];
-      if (!validateLabel(label)) {
-        break;
+      for (const lf of label.literalForm) {
+        addLabel(newLabels, lf, lf["@language"]);
       }
-    }
-    try {
-      // key already exists
-      newLabels[language].push(label);
-    } catch (e) {
-      // key doesn't exist
-      newLabels[language] = [];
-      newLabels[language].push(label);
     }
   }
   return newLabels;
+}
+
+function addLabel(newLabels, label: string, language: string) {
+  try {
+    // key already exists
+    newLabels[language].push(label);
+  } catch (e) {
+    // key doesn't exist
+    newLabels[language] = [];
+    newLabels[language].push(label);
+  }
 }
 
 /**

--- a/apps/sps-termportal-web/utils/utils.ts
+++ b/apps/sps-termportal-web/utils/utils.ts
@@ -62,7 +62,7 @@ export function getConceptDisplaytitle(concept): string | null {
     for (const label of ["prefLabel", "altLabel"]) {
       if (concept?.[label]) {
         if (concept?.[label][lang]) {
-          title = concept[label][lang]?.[0]?.literalForm["@value"];
+          title = concept[label][lang]?.[0]?.["@value"];
           break;
         }
       }


### PR DESCRIPTION
Some collections of FBK use skosxl:literalForm as a set. Fix display if those labels