### PR TITLE
feat(tp): execute search in autocomplete overlay click

### DIFF
--- a/apps/sps-termportal-web/components/AutoComplete.vue
+++ b/apps/sps-termportal-web/components/AutoComplete.vue
@@ -637,6 +637,8 @@ export default {
         originalEvent: event,
         target: this.$el,
       });
+      // FIX: Search on click
+      this.$emit("execSearch");
     },
     onOverlayKeyDown(event) {
       switch (event.code) {


### PR DESCRIPTION
Selecting a match in the autocomplete dropdown only sets searchterm. Should also execute search.