### PR TITLE
fix(tpa): termbases status numbering util by including zero

### DIFF
--- a/apps/sps-termportal-admin/utils/utils.ts
+++ b/apps/sps-termportal-admin/utils/utils.ts
@@ -7,5 +7,5 @@ export function formatTimespan(start: string, end: string) {
 
 export function numberStatus(status: string) {
   const index = statusOrder.indexOf(status);
-  return `${index > 0 ? index + 1 + "." : ""} ${status || ""}`;
+  return `${index >= 0 ? index + 1 + "." : ""} ${status || ""}`;
 }


### PR DESCRIPTION
- first status "kjent" wasn't numbered -> fix check to include first instance