### PR TITLE
Deploy API to NREC

### DIFF
--- a/apps/api/compose.yaml
+++ b/apps/api/compose.yaml
@@ -14,38 +14,4 @@ services:
     environment:
       NODE_ENV: production
     ports:
-      - 3000:3000
-
-# The commented out section below is an example of how to define a PostgreSQL
-# database that your application can use. `depends_on` tells Docker Compose to
-# start the database before your application. The `db-data` volume persists the
-# database data between container restarts. The `db-password` secret is used
-# to set the database password. You must create `db/password.txt` and add
-# a password of your choosing to it before running `docker-compose up`.
-#     depends_on:
-#       db:
-#         condition: service_healthy
-#   db:
-#     image: postgres
-#     restart: always
-#     user: postgres
-#     secrets:
-#       - db-password
-#     volumes:
-#       - db-data:/var/lib/postgresql/data
-#     environment:
-#       - POSTGRES_DB=example
-#       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
-#     expose:
-#       - 5432
-#     healthcheck:
-#       test: [ "CMD", "pg_isready" ]
-#       interval: 10s
-#       timeout: 5s
-#       retries: 5
-# volumes:
-#   db-data:
-# secrets:
-#   db-password:
-#     file: db/password.txt
-
+      - 3009:3000


### PR DESCRIPTION
We want to have the Hono API deployed on NREC. Deployment on NREC will make sure that we do not use up resources on Vercel.

The app to be deployed is `apps/api`. It currently have none working docker files.