### PR TITLE
Fix #tpa handling of absent people data

### DIFF
--- a/apps/sps-termportal-admin/components/InsightPeople.vue
+++ b/apps/sps-termportal-admin/components/InsightPeople.vue
@@ -66,7 +66,7 @@ const procdata = computed(() => {
         ?.map(
           (group) =>
             group.label +
-            ` (${group.qualifiedMembership[0].timespan.edtf}, ${group.qualifiedMembership[0].role})`
+            ` (${group.qualifiedMembership[0].timespan?.edtf}, ${group.qualifiedMembership[0].role})`
         )
         .join(", "),
       organization: person.qualifiedDelegation

--- a/apps/sps-termportal-admin/components/InsightReferenceGroup.vue
+++ b/apps/sps-termportal-admin/components/InsightReferenceGroup.vue
@@ -48,8 +48,8 @@ const procdata = computed(() => {
     .map((group) => {
       const map = {
         label: group.label,
-        count: group.qualifiedMembership.length,
-        timespan: group.termgroups[0].qualifiedConsultation[0].timespan.edtf,
+        count: group.qualifiedMembership ? group.qualifiedMembership.length : 0,
+        timespan: group.termgroups[0].qualifiedConsultation[0].timespan?.edtf,
         termgroup: group.termgroups[0].label,
         // count: group.members.filter((member) => member.termgroups.length > 0)
         //   .length,


### PR DESCRIPTION
- reference group doesn't allow for undefined consultation
- people in term groups: didn't allow for absent join date