### PR TITLE
Feat #tpa limit institution stats to published and created

### DIFF
--- a/apps/sps-termportal-admin/components/InsightInstitutions.vue
+++ b/apps/sps-termportal-admin/components/InsightInstitutions.vue
@@ -59,8 +59,6 @@ const query = `
   `;
 const { data } = useLazySanityQuery(query);
 
-//      person.termgroups.map((tg) => tg?.termbase).flat().length > 0
-
 const procdata = computed(() => {
   const mapped = data.value
     ?.filter(

--- a/apps/sps-termportal-admin/components/InsightInstitutions.vue
+++ b/apps/sps-termportal-admin/components/InsightInstitutions.vue
@@ -1,6 +1,15 @@
 <template>
   <section>
     <h2 class="mb-3 text-xl">Institutions participating in termgroups</h2>
+    <div class="space-y-2">
+      <p>
+        List of insitutions with a count of associated people in termgroups that
+        have 'opprettet' or 'publisert' termbases.
+      </p>
+      <p>
+        The lookup follows the logic: Organization->Person->Termgroup->Termbase
+      </p>
+    </div>
     <DataTable
       ref="datatable"
       v-model:filters="filters"

--- a/apps/sps-termportal-admin/components/InsightInstitutionsTbs.vue
+++ b/apps/sps-termportal-admin/components/InsightInstitutionsTbs.vue
@@ -1,6 +1,13 @@
 <template>
   <section>
     <h2 class="mb-3 text-xl">Institutions responsible for termbases</h2>
+    <div class="">
+      <p>
+        List of institutions registered as responsible for one or more
+        termbases. Only termbases that have the status 'opprettet' or
+        'publisert' are included in the count.
+      </p>
+    </div>
     <DataTable
       ref="datatable"
       v-model:filters="filters"
@@ -30,7 +37,9 @@ const query = `
     *[_type == "organization"]
     { _id,
       label,
-      "termbases": *[_type == "termbase" && references(^._id)]{
+      "termbases": *[_type == "termbase" &&
+                     references(^._id) &&
+                     (status == 'publisert' || status == 'opprettet')]{
         qualifiedAttribution[group._ref == ^.^._id]{...}
       }
     }


### PR DESCRIPTION
Institution insights for termbases and people:
- only created and published termbases should be considered when generating associated data