### PR TITLE
Fix #tpa include empty tbs in overview

### DIFF
--- a/apps/sps-termportal-admin/components/TermbaseOverview.vue
+++ b/apps/sps-termportal-admin/components/TermbaseOverview.vue
@@ -321,6 +321,7 @@
 
 <script setup lang="ts">
 import { FilterMatchMode } from "primevue/api";
+import { hiddenCollections } from "~/utils/constants";
 import { getDaysDiff } from "~/utils/utils";
 
 const runtimeConfig = useRuntimeConfig();
@@ -411,7 +412,7 @@ const merged = computed(() => {
       };
       return tmp;
     })
-    .filter((termbase) => !["DOMENE", "MRT2"].includes(termbase.id));
+    .filter((termbase) => !hiddenCollections.includes(termbase.id));
 
   // get termbases that are not present in the wiki
   if (enriched && cmsdata.value) {

--- a/apps/sps-termportal-admin/server/utils/genOverviewQuery.ts
+++ b/apps/sps-termportal-admin/server/utils/genOverviewQuery.ts
@@ -7,10 +7,11 @@ export default function () {
   SELECT ?id ?label (count(?concept) as ?concepts) ?license
   WHERE {
     GRAPH <urn:x-arq:UnionGraph> {
-      ?concept skosp:memberOf ?tb .
-      ?tb dct:identifier ?id .
-      ?tb rdfs:label ?label .
+      ?tb rdf:type skos:Collection ;
+          dct:identifier ?id ;
+          rdfs:label ?label .
       OPTIONAL {
+        ?concept skosp:memberOf ?tb .
         ?tb dct:license ?license .
       }
       FILTER ( lang(?label) = 'nb') .

--- a/apps/sps-termportal-admin/utils/constants.ts
+++ b/apps/sps-termportal-admin/utils/constants.ts
@@ -53,3 +53,5 @@ export const esCachedQueries = [
 export const reportReminder = {
   interval: { reminder: 120, error: 60 },
 };
+
+export const hiddenCollections = ["DOMENE", "LISENS", "MRT2"];


### PR DESCRIPTION
The overview query included a mandatory "memberOf" so empty termbases weren't exported. -> make prop optional.

Extend hidden termbases with LISENS, move const to constants file

