### PR TITLE
fix(tpw): insert divs between content docs

### DIFF
--- a/apps/sps-termportal-web/pages/om.vue
+++ b/apps/sps-termportal-web/pages/om.vue
@@ -36,6 +36,7 @@
               :path="`/${locale}/om/fagrad`"
               class="content-wrapper"
             />
+            <div></div>
             <ContentDoc
               :key="`mandat${locale}`"
               :head="false"
@@ -54,6 +55,7 @@
               :path="`/${locale}/om/history`"
               class="content-wrapper"
             />
+            <div></div>
             <ContentDoc
               :key="`publications${locale}`"
               :path="`/${locale}/om/publications`"


### PR DESCRIPTION
Nuxt content docs directly next to each other change position when locale is changed. Effects `om termportalen`

Fix (tmp): insert separator element