### PR TITLE
Tpw/en handling autocomplete

### DIFF
--- a/apps/sps-termportal-web/server/utils/genAutocompleteQuery.ts
+++ b/apps/sps-termportal-web/server/utils/genAutocompleteQuery.ts
@@ -29,7 +29,7 @@ export function genAutocompleteQuery(
     } else if (languageCode === "en") {
       return `FILTER ( lang(?lit) = "en" || lang(?lit) = "en-GB" || lang(?lit) = "en-US" )`;
     } else {
-      return `FILTER ( lang(?lit) = ${languageCode})`;
+      return `FILTER ( lang(?lit) = "${languageCode}")`;
     }
   }
 

--- a/apps/sps-termportal-web/server/utils/genAutocompleteQuery.ts
+++ b/apps/sps-termportal-web/server/utils/genAutocompleteQuery.ts
@@ -10,8 +10,7 @@ export function genAutocompleteQuery(
   const sanitizedLit = term.replaceAll('"', '\\"');
   const sanitizedIndex = sanitizeTerm(term);
   const multiIndex = sanitizedIndex.split(" ").join(" AND ");
-  const lang = genTQLangArgument(searchOptions.language)[0];
-  const graph = genTQGraphValue(searchOptions.termbase)[0];
+  const languageCode = searchOptions.language[0];
   const context = getContextFilter(searchOptions);
   const contextFilter = () => {
     if (context[0]) {
@@ -24,6 +23,15 @@ export function genAutocompleteQuery(
       return "";
     }
   };
+  function languageFilter(languageCode: string) {
+    if (languageCode === "all") {
+      return "";
+    } else if (languageCode === "en") {
+      return `FILTER ( lang(?lit) = "en" || lang(?lit) = "en-GB" || lang(?lit) = "en-US" )`;
+    } else {
+      return `FILTER ( lang(?lit) = ${languageCode})`;
+    }
+  }
 
   /**
    * Relevance
@@ -43,8 +51,9 @@ export function genAutocompleteQuery(
   GRAPH <urn:x-arq:UnionGraph> {
       {
         SELECT DISTINCT ?litstr {
-          ( ?l ?sc ?lit ) text:query ( "\\"${sanitizedIndex}\\"" ${lang} ) .
+          ( ?l ?sc ?lit ) text:query ( "\\"${sanitizedIndex}\\"" ) .
           ${contextFilter()}
+          ${languageFilter(languageCode)}
           BIND ( str(?lit) as ?litstr )
           FILTER ( ?litstr = "${sanitizedLit}" )
         }
@@ -52,8 +61,9 @@ export function genAutocompleteQuery(
       UNION
       {
         SELECT DISTINCT ?litstr {
-          ( ?l ?sc ?lit ) text:query ("\\"${sanitizedIndex}\\"" ${lang}) .
+          ( ?l ?sc ?lit ) text:query ("\\"${sanitizedIndex}\\"") .
           ${contextFilter()}
+          ${languageFilter(languageCode)}
           BIND ( str(?lit) as ?litstr )
           FILTER ( lcase(?litstr) = lcase("${sanitizedLit}")
                    && ?litstr != "${sanitizedLit}"
@@ -63,8 +73,9 @@ export function genAutocompleteQuery(
       UNION
       {
         SELECT DISTINCT ?litstr {
-          ( ?l ?sc ?lit ) text:query ("${multiIndex}*" ${lang}) .
+          ( ?l ?sc ?lit ) text:query ("${multiIndex}*") .
           ${contextFilter()}
+          ${languageFilter(languageCode)}
           BIND ( str(?lit) as ?litstr )
           FILTER ( strStarts( lcase(?litstr), lcase("${sanitizedLit}") ) &&
                    lcase(?litstr) != lcase("${sanitizedLit}")
@@ -76,8 +87,9 @@ export function genAutocompleteQuery(
       UNION
       {
         SELECT DISTINCT ?litstr {
-          ( ?l ?sc ?lit ) text:query ("${multiIndex}*" ${lang}) .
+          ( ?l ?sc ?lit ) text:query ("${multiIndex}*") .
           ${contextFilter()}
+          ${languageFilter(languageCode)}
           BIND ( str(?lit) as ?litstr )
           FILTER ( !strStarts( lcase(?litstr), lcase("${sanitizedLit}") )
                    && contains( ?litstr, lcase("${sanitizedLit}") )


### PR DESCRIPTION
Autocomplete queries use the jena `lang:lc` pattern for language codes. This requires `UNION` when using multiple codes. 

Refactor to `FILTER`-use for `en` and `en-GB`, `en-US`