### PR TITLE
Add-sets-api

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -10,6 +10,7 @@ import { env } from './env'
 import item from './routes/items/item.route'
 import items from './routes/items/items.route'
 import person from './routes/person/person.route'
+import set from './routes/sets/set.route'
 import group from './routes/group/group.route'
 import ns from './routes/ns.route'
 import reference from './routes/references.route'
@@ -41,6 +42,7 @@ app.get('/', (c) => {
 app.route('/items', items)
 app.route('/items', item)
 app.route('/person', person)
+app.route('/sets', set)
 app.route('/group', group)
 // The reference route is the OpenAPI documentation UI.
 app.route('/reference', reference)

--- a/apps/api/src/routes/sets/set-query.ts
+++ b/apps/api/src/routes/sets/set-query.ts
@@ -1,0 +1,76 @@
+export const setQuery = `
+  PREFIX muna: <http://muna.xyz/model/0.1/>
+  PREFIX crm: <http://www.cidoc-crm.org/cidoc-crm/>
+  PREFIX ecrm: <http://erlangen-crm.org/current/>
+  PREFIX ubbont: <http://data.ub.uib.no/ontology/>
+  PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+  PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+  PREFIX dbo: <http://dbpedia.org/ontology/>
+  PREFIX dc: <http://purl.org/dc/elements/1.1/>
+  PREFIX dct: <http://purl.org/dc/terms/>
+  PREFIX schema: <http://schema.org/>
+  PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+  PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+  PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+  PREFIX bibo: <http://purl.org/ontology/bibo/>
+  PREFIX mo: <http://purl.org/ontology/mo/>
+  PREFIX geo-deling: <http://vocab.lenka.no/geo-deling#>
+  PREFIX wgs: <http://www.w3.org/2003/01/geo/wgs84_pos#>
+  PREFIX dcmitype: <http://purl.org/dc/dcmitype/>
+  PREFIX event: <http://purl.org/NET/c4dm/event.owl#>
+  PREFIX geonames: <http://www.geonames.org/ontology#>
+  PREFIX exif: <http://www.w3.org/2003/12/exif/ns#>
+  PREFIX edm: <http://www.europeana.eu/schemas/edm/>
+  PREFIX org: <http://www.w3.org/ns/org#>
+  PREFIX bio: <http://purl.org/vocab/bio/0.1/>
+  PREFIX frbr: <http://vocab.org/frbr/core#>
+  PREFIX owl: <http://www.w3.org/2002/07/owl#>
+  PREFIX ore: <http://www.openarchives.org/ore/terms/>
+  PREFIX nie: <http://www.semanticdesktop.org/ontologies/nie/#>
+  PREFIX locah: <http://data.archiveshub.ac.uk/def/>
+  PREFIX lexvo: <http://lexvo.org/ontology#>
+  PREFIX cc: <http://creativecommons.org/ns#>
+  PREFIX sc: <http://iiif.io/api/presentation/3#>
+  PREFIX oa: <http://www.w3.org/ns/oa#>
+  PREFIX iiif_prezi: <http://iiif.io/api/presentation/3#>
+  PREFIX as: <http://www.w3.org/ns/activitystreams#>
+  PREFIX la: <https://linked.art/ns/terms/>
+
+  CONSTRUCT { 
+    ?uri a la:Set ;
+      ?p ?o ;
+      crm:P2_has_type ?type ;
+      rdfs:label ?label ;
+      foaf:homepage ?homepage .
+    ?o a ?oClass ;
+      ?p2 ?o2 ;
+      dct:identifier ?oIdentifier ;
+      rdfs:label ?oLabel ;
+      ubbont:hasURI ?hasURI .
+  } WHERE { 
+    VALUES ?id {"%id"}
+    VALUES ?types { bibo:Collection }
+    ?uri dct:identifier ?id ;
+      rdf:type ?types ;
+      ?p ?o ;
+      a ?class .
+    OPTIONAL {?uri dct:title ?title } .
+    OPTIONAL {?uri foaf:name ?name } .
+    OPTIONAL {?uri skos:prefLabel ?prefLabel } .
+    OPTIONAL {?uri rdfs:label ?rdfsLabel } .
+    BIND (COALESCE(?title,?name,?prefLabel,?rdfsLabel) AS ?label) .  
+    OPTIONAL { 
+      ?o a ?oClass ;
+      dct:identifier ?oIdentifier ;
+      OPTIONAL { ?o foaf:gender ?oGender } .
+      OPTIONAL { ?o (dct:title|foaf:name|skos:prefLabel|rdfs:label) ?oLabel } . 
+      OPTIONAL { ?o ubbont:hasURI ?hasURI } .
+      FILTER(?oClass != rdfs:Class) .
+    }
+    FILTER(STRENDS(STR(?uri), ?id)) .
+    FILTER(?o != ?uri) .
+    BIND(REPLACE(STR(?class), ".+[/#]([^/#]+)$", "$1") as ?type) .
+    BIND(iri(REPLACE(str(?uri), "http://data.ub.uib.no","https://marcus.uib.no","i")) as ?homepage) .
+    FILTER(?p NOT IN (rdf:type, foaf:made, dct:hasPart, ubbont:cataloguer, ubbont:reproduced, ubbont:internalNote, ubbont:showWeb, ubbont:clause, ubbont:hasRepresentation, ubbont:hasThumbnail, dct:relation, dc:relation, dct:isReferencedBy, ubbont:hasTranscription, skos:inScheme, ubbont:published))
+  }
+`

--- a/apps/api/src/routes/sets/set.route.ts
+++ b/apps/api/src/routes/sets/set.route.ts
@@ -1,0 +1,216 @@
+import client from '@shared/clients/es-client'
+import { env } from '@env'
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import { FailureSchema, TODO } from '@shared/models'
+import { normalizeJsonLdToArray, reorderDocument, sqb, useFrame } from 'utils'
+import ubbontContext from 'jsonld-contexts/src/ubbontContext'
+import { ContextDefinition } from 'jsonld'
+import { endpointUrl } from '@shared/clients/sparql-chc-client'
+import { setQuery } from './set-query'
+import { constructIIIFCollection } from '@shared/mappers/iiif/constructIIIFCollection'
+
+const route = new OpenAPIHono()
+
+const desiredOrder: string[] = ['@context', 'id', 'type', '_label', '_available', '_modified', 'identified_by']
+
+const SetSchema = z.record(z.string()).openapi('Set')
+
+export const SetParamsSchema = z.object({
+  as: z
+    .enum(['iiif', 'la', 'ubbont'])
+    .optional()
+    .default('la')
+    .openapi({
+      param: {
+        name: 'as',
+        in: 'query',
+      },
+      example: 'la',
+    }),
+})
+
+export const SetIdParamsSchema = z.object({
+  id: z.string()
+    .openapi({
+      param: {
+        name: 'id',
+        in: 'path',
+        required: true,
+      },
+      example: 'fd217222-8193-4122-bd03-57fd68565fb5',
+    })
+})
+
+export const getSet = createRoute({
+  method: 'get',
+  path: '/{id}',
+  request: {
+    params: SetIdParamsSchema,
+    query: SetParamsSchema,
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: SetSchema,
+        },
+      },
+      description: 'Retrieve a set.',
+    },
+    404: {
+      content: {
+        'application/json': {
+          schema: FailureSchema,
+        },
+      },
+      description: 'Failure message.',
+    },
+  },
+  tags: ['Set'],
+})
+
+route.openapi(getSet, async (c) => {
+  const id = c.req.param('id')
+  const as = c.req.query('as')
+
+  if (as === 'ubbont') {
+    try {
+      const response = await fetch(`${endpointUrl}?query=${encodeURIComponent(sqb(setQuery, { id }))}&output=json`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch item: ${response.statusText}`);
+      }
+      const data = await response.json();
+
+      // Check if data is empty by checking if it's falsy, has no keys, or is an empty object
+      if (!data || Object.keys(data).length === 0) {
+        return c.json({ error: true, message: 'Not found' }, 404)
+      }
+
+      const normalizedData = normalizeJsonLdToArray(data)
+      // Find the matching item in the graph
+      const matchingItem = normalizedData.find((item: any) => item['dct:identifier'] === id);
+
+      if (!matchingItem) {
+        return c.json({ error: true, message: 'Group not found in graph' }, 404);
+      }
+
+      const url = matchingItem['@id'].replace('j.0:', 'http://data.ub.uib.no/');
+
+      let framed = await useFrame({ data, context: ubbontContext as ContextDefinition, type: 'Group', id: url });
+      framed['@context'] = ["https://api.ub.uib.no/ns/ubbont/context.json"];
+      return c.json(reorderDocument(framed, desiredOrder));
+    } catch (error) {
+      throw new Error(`Error fetching item ${id}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  if (as === 'iiif') {
+    try {
+      // First query: Get the collection
+      const setData: TODO = await client.search({
+        index: [`search-chc-sets*`],
+        query: {
+          term: {
+            "id.keyword": id
+          },
+        }
+      })
+
+      if (setData.hits?.total.value === 0) {
+        return c.json({ error: true, message: 'Not found' }, 404)
+      }
+
+      const set = setData?.hits?.hits?.[0]?._source
+
+      if (!set) {
+        return c.json({ error: true, message: 'Item has not been catalogued' }, 404)
+      }
+
+      // Second query: Get items that reference this collection
+      const itemsData: TODO = await client.search({
+        index: [`search-chc`],
+        query: {
+          bool: {
+            should: [
+              {
+                nested: {
+                  path: "member_of",
+                  query: {
+                    term: {
+                      "member_of.id.keyword": `${env.PROD_URL}/sets/${id}`
+                    }
+                  }
+                }
+              },
+            ]
+          }
+        },
+        sort: [
+          /* {
+            "type.keyword": "desc"
+          }, */
+          {
+            "id.keyword": "asc"
+          }
+        ],
+        _source: ["id", "type", "_label", "representation"],
+        size: 10000
+      })
+
+      // Add the items to the collection data
+      const items = itemsData?.hits?.hits?.map((hit: any) => hit._source) ?? undefined
+      const itemsCount = itemsData?.hits?.total?.value ?? 1
+
+      const setWithItems = {
+        ...set,
+        items
+      }
+
+      const manifest = constructIIIFCollection(setWithItems)
+      // Add total item count to response header
+      c.header('X-Total-Count', itemsCount.toString())
+      return c.body(
+        JSON.stringify(manifest),
+        200,
+        {
+          'Content-Type': 'application/ld+json;profile="http://iiif.io/api/presentation/3/context.json"'
+        }
+      )
+    } catch (error) {
+      console.error(error)
+      return c.json({ error: true, message: "Ups, something went wrong!" }, 404)
+    }
+  }
+
+  // Default to la
+  try {
+    const data: TODO = await client.search<any>({
+      index: `search-chc-sets*`,
+      query: {
+        match_phrase: {
+          "id": id
+        },
+      }
+    })
+
+    if (data?.hits?.total?.value === 0) {
+      return c.json({ error: true, message: 'Not found' }, 404)
+    }
+
+    const item = data.hits.hits[0]._source
+
+    // Rewrite _id to use the id from the URL parameter
+    const itemWithNewId = {
+      ...item,
+      id: `${env.PROD_URL}/items/${item.id}`
+    }
+
+    return c.json(reorderDocument(itemWithNewId as Document, desiredOrder))
+  } catch (error) {
+    console.error(error)
+    return c.json({ error: true, message: "Ups, something went wrong!" }, 404)
+  }
+})
+
+
+export default route

--- a/apps/api/src/shared/mappers/iiif/constructIIIFCollection.ts
+++ b/apps/api/src/shared/mappers/iiif/constructIIIFCollection.ts
@@ -1,0 +1,141 @@
+// Converts a Linked Art "Set" object to a minimal IIIF Presentation 3 Collection object
+
+type LanguageMap = { [lang: string]: string[] };
+
+interface IIIFCollection {
+  '@context': string[];
+  id: string;
+  type: 'Collection' | 'Manifest';
+  label: LanguageMap;
+  summary?: LanguageMap;
+  items?: any[];
+}
+
+interface IIIFManifest {
+  id: string;
+  type: 'Manifest' | 'Collection';
+  label: LanguageMap;
+  thumbnail?: Array<{
+    id: string;
+    type: 'Image';
+    format: string;
+  }>;
+}
+
+function mapItemToIIIFManifest(item: any): IIIFManifest {
+  // Get the label from _label
+  const label = item._label || '';
+
+  // Find thumbnail from representation
+  let thumbnail: Array<{ id: string; type: 'Image'; format: string }> | undefined;
+
+  if (Array.isArray(item.representation)) {
+    // Look for the first representation that has a thumbnail
+    for (const rep of item.representation) {
+      if (Array.isArray(rep.digitally_shown_by)) {
+        for (const digital of rep.digitally_shown_by) {
+          // Check if this is classified as a thumbnail
+          if (Array.isArray(digital.classified_as) &&
+            digital.classified_as.some((c: any) => c._label === 'Thumbnails')) {
+
+            if (Array.isArray(digital.access_point)) {
+              const accessPoint = digital.access_point[0];
+              if (accessPoint && accessPoint.id) {
+                thumbnail = [{
+                  id: accessPoint.id,
+                  type: 'Image',
+                  format: 'image/jpeg' // Default format, could be made dynamic
+                }];
+                break;
+              }
+            }
+          }
+        }
+        if (thumbnail) break;
+      }
+    }
+  }
+
+  // Generate URL and type based on item type
+  const baseUrl = item.type === 'HumanMadeObject'
+    ? `https://api.ub.uib.no/items/${item.id}?as=iiif`
+    : `https://api.ub.uib.no/sets/${item.id}?as=iiif`;
+
+  const itemType = item.type === 'HumanMadeObject' ? 'Manifest' : 'Collection';
+
+  const manifest: IIIFManifest = {
+    id: baseUrl,
+    type: itemType,
+    label: { no: [label] }
+  };
+
+  if (thumbnail) {
+    manifest.thumbnail = thumbnail;
+  }
+
+  return manifest;
+}
+
+export function constructIIIFCollection(set: any): IIIFCollection {
+  // Get label (primary name, fallback to _label)
+  let label: string | undefined;
+  if (Array.isArray(set.identified_by)) {
+    const primary = set.identified_by.find(
+      (id: any) =>
+        id.type === 'Name' &&
+        Array.isArray(id.classified_as) &&
+        id.classified_as.some(
+          (c: any) =>
+            c.id === 'http://vocab.getty.edu/aat/300404670' ||
+            c._label === 'Primary Name'
+        )
+    );
+    label = primary?.content;
+  }
+  if (!label && set._label) label = set._label;
+
+  // Get summary (from referred_to_by, Description)
+  let summary: string | undefined;
+  if (Array.isArray(set.referred_to_by)) {
+    const desc = set.referred_to_by.find(
+      (r: any) =>
+        Array.isArray(r.classified_as) &&
+        r.classified_as.some(
+          (c: any) =>
+            c.id === 'http://vocab.getty.edu/aat/300435416' ||
+            c._label === 'Description'
+        )
+    );
+    summary = desc?.content;
+  }
+
+  // Map type: "Set" -> "Collection", "Humanmadeobject" -> "Manifest", other types remain as-is
+  let iiifType: 'Collection' | 'Manifest';
+  if (set.type === 'Set') {
+    iiifType = 'Collection';
+  } else if (set.type === 'HumanMadeObject') {
+    iiifType = 'Manifest';
+  } else {
+    iiifType = 'Collection'; // Default for other types
+  }
+
+  // Generate URL based on type
+  const baseUrl = set.type === 'HumanMadeObject'
+    ? `https://api.ub.uib.no/items/${set.id}`
+    : `https://api.ub.uib.no/sets/${set.id}`;
+
+  // Compose IIIF Collection object
+  const iiif: IIIFCollection = {
+    '@context': ['http://iiif.io/api/presentation/3/context.json'],
+    id: baseUrl,
+    type: iiifType,
+    label: { no: [label || ''] },
+  };
+  if (summary) {
+    iiif.summary = { no: [summary] };
+  }
+  if (set.items) {
+    iiif.items = set.items.map(mapItemToIIIFManifest);
+  }
+  return iiif;
+}

--- a/packages/ingest-cli/src/clients/es-client.ts
+++ b/packages/ingest-cli/src/clients/es-client.ts
@@ -6,7 +6,9 @@ const client = new Client({
   Connection: HttpConnection, // TODO: remove when Bun supports ConnectionError (see https://github.com/oven-sh/bun/issues/7920)
   auth: {
     apiKey: env.ES_APIKEY
-  }
+  },
+  requestTimeout: 120000, // 2 minutes timeout
+  pingTimeout: 30000     // 30 seconds ping timeout
 });
 
 export const observeClient = new Client({
@@ -14,7 +16,9 @@ export const observeClient = new Client({
   Connection: HttpConnection, // TODO: remove when Bun supports ConnectionError (see https://github.com/oven-sh/bun/issues/7920)
   auth: {
     apiKey: env.OBSERVE_ES_APIKEY
-  }
+  },
+  requestTimeout: 60000, // 1 minute timeout for logging
+  pingTimeout: 30000     // 30 seconds ping timeout
 });
 
 export default client;

--- a/packages/ingest-cli/src/constants.ts
+++ b/packages/ingest-cli/src/constants.ts
@@ -34,6 +34,7 @@ PREFIX sc: <http://iiif.io/api/presentation/3#>
 PREFIX oa: <http://www.w3.org/ns/oa#>
 PREFIX iiif_prezi: <http://iiif.io/api/presentation/3#>
 PREFIX as: <http://www.w3.org/ns/activitystreams#>
+PREFIX la: <https://linked.art/ns/terms/>
 `
 
 /**

--- a/packages/ingest-cli/src/env.ts
+++ b/packages/ingest-cli/src/env.ts
@@ -14,6 +14,7 @@ const schema = z.object({
   API_ES_WRITE_TOKEN: z.string(),
   OBSERVE_ES_HOST: z.string().url(),
   OBSERVE_ES_APIKEY: z.string(),
+  SPARQL_CHC_ENDPOINT: z.string().url(),
 });
 
 const parsed = schema.safeParse(process.env);

--- a/packages/ingest-cli/src/index.ts
+++ b/packages/ingest-cli/src/index.ts
@@ -15,6 +15,8 @@ import { ingestPeople } from './utils/ingest-people/ingest-people';
 import { ingestPerson } from './utils/ingest-people/ingest-person';
 import { ingestGroups } from './utils/ingest-groups/ingest-groups';
 import { ingestGroup } from './utils/ingest-groups/ingest-group';
+import { ingestSets } from './utils/ingest-sets/ingest-sets';
+import { ingestSet } from './utils/ingest-sets/ingest-set';
 
 const program = new Command();
 program
@@ -50,6 +52,9 @@ program
           break;
         case 'groups':
           await ingestGroups(limit, page, overwrite);
+          break;
+        case 'sets':
+          await ingestSets(limit, page, overwrite);
           break;
         case 'wab':
           await ingestWab();
@@ -115,6 +120,23 @@ program
       process.exit(1);
     }
   });
+
+program
+  .command('ingest-set')
+  .description('Ingest a single set by ID')
+  .argument('<id>', 'ID of the set to ingest')
+  .action(async (id) => {
+    console.log(`Ingesting set with ID: ${id}`);
+
+    try {
+      await ingestSet(id);
+      console.log(`Successfully ingested set with ID: ${id}`);
+    } catch (error) {
+      console.error(`Error ingesting set with ID ${id}:`, error);
+      process.exit(1);
+    }
+  });
+
 // Templates command
 program
   .command('templates')

--- a/packages/ingest-cli/src/utils/indexers/mappings/chc.ts
+++ b/packages/ingest-cli/src/utils/indexers/mappings/chc.ts
@@ -57,8 +57,8 @@ export const chcSourceSettings: IndicesPutIndexTemplateRequest = {
   }
 }
 
-export const chcIdTemplateComponent: IndicesPutIndexTemplateRequest = {
-  "name": "chc-id-template-component",
+export const chcCorePropertiesTemplateComponent: IndicesPutIndexTemplateRequest = {
+  "name": "chc-core-properties-template-component",
   "template": {
     "mappings": {
       "properties": {
@@ -69,12 +69,20 @@ export const chcIdTemplateComponent: IndicesPutIndexTemplateRequest = {
               "type": "keyword"
             }
           }
-        }
+        },
+        "type": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword"
+            }
+          }
+        },
       },
     }
   },
   "_meta": {
-    "description": "Mapping for id",
+    "description": "Mapping for core properties",
   }
 }
 
@@ -120,7 +128,11 @@ export const chcOwnersTemplateComponent: IndicesPutIndexTemplateRequest = {
           "properties": {
             "id": {
               "type": "text",
-              "index": false,
+              "fields": {
+                "keyword": {
+                  "type": "keyword"
+                }
+              }
             },
             "type": {
               "type": "text",
@@ -138,6 +150,38 @@ export const chcOwnersTemplateComponent: IndicesPutIndexTemplateRequest = {
   }
 }
 
+export const chcMemberOfTemplateComponent: IndicesPutIndexTemplateRequest = {
+  "name": "chc-member-of-template-component",
+  "template": {
+    "mappings": {
+      "properties": {
+        "member_of": {
+          "type": "nested",
+          "properties": {
+            "id": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "type": {
+              "type": "text",
+              "index": false,
+            },
+            "_label": labelComponent('member_of._label_all'),
+            "_label_all": labelAllComponent
+          }
+        }
+      }
+    }
+  },
+  "_meta": {
+    "description": "Mapping for member_of",
+  }
+}
+
 export const chcProductionTemplateComponent: IndicesPutIndexTemplateRequest = {
   "name": "chc-production-template-component",
   "template": {
@@ -148,7 +192,11 @@ export const chcProductionTemplateComponent: IndicesPutIndexTemplateRequest = {
           "properties": {
             "id": {
               "type": "text",
-              "index": false,
+              "fields": {
+                "keyword": {
+                  "type": "keyword"
+                }
+              }
             },
             "type": {
               "type": "text",
@@ -161,7 +209,11 @@ export const chcProductionTemplateComponent: IndicesPutIndexTemplateRequest = {
               "properties": {
                 "id": {
                   "type": "text",
-                  "index": false,
+                  "fields": {
+                    "keyword": {
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "type": {
                   "type": "text",
@@ -176,7 +228,11 @@ export const chcProductionTemplateComponent: IndicesPutIndexTemplateRequest = {
               "properties": {
                 "id": {
                   "type": "text",
-                  "index": false,
+                  "fields": {
+                    "keyword": {
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "type": {
                   "type": "text",

--- a/packages/ingest-cli/src/utils/indexers/pipelines/chc.ts
+++ b/packages/ingest-cli/src/utils/indexers/pipelines/chc.ts
@@ -1,7 +1,7 @@
 export const chc = {
-  id: "chc",
+  id: "chc-pipeline",
   version: 1,
-  description: "Marcus-next pipeline",
+  description: "Cultural Heritage Collections pipeline",
   /* processors: [
     {
       script: {

--- a/packages/ingest-cli/src/utils/indexers/settings/log.ts
+++ b/packages/ingest-cli/src/utils/indexers/settings/log.ts
@@ -1,5 +1,5 @@
 export const logSettings = {
-  "name": "log-settings",
+  "name": "chc-log-settings",
   "template": {
     "settings": {
       "index.lifecycle.name": "log-lifecycle-policy"

--- a/packages/ingest-cli/src/utils/indexers/templates.ts
+++ b/packages/ingest-cli/src/utils/indexers/templates.ts
@@ -1,5 +1,6 @@
+import { IndicesPutIndexTemplateRequest } from '@elastic/elasticsearch/lib/api/types';
 import { mappings } from './mappings';
-import { chcDataFieldTemplateComponent, chcIdTemplateComponent, chcLabelTemplateComponent, chcOwnersTemplateComponent, chcProductionTemplateComponent, chcSourceSettings } from './mappings/chc';
+import { chcDataFieldTemplateComponent, chcCorePropertiesTemplateComponent, chcLabelTemplateComponent, chcMemberOfTemplateComponent, chcOwnersTemplateComponent, chcProductionTemplateComponent, chcSourceSettings } from './mappings/chc';
 
 export const logTemplate = {
   "name": "log-template",
@@ -12,19 +13,23 @@ export const logTemplate = {
   }
 }
 
-export const chcTemplate = {
+export const chcTemplate: IndicesPutIndexTemplateRequest = {
   "name": "chc-settings",
   "index_patterns": ["search-chc*"],
   "composed_of": [
     chcSourceSettings.name,
     chcDataFieldTemplateComponent.name,
-    chcIdTemplateComponent.name,
+    chcCorePropertiesTemplateComponent.name,
     chcLabelTemplateComponent.name,
     chcOwnersTemplateComponent.name,
     chcProductionTemplateComponent.name,
+    chcMemberOfTemplateComponent.name,
   ],
   "template": {
     "settings": {
+      "index": {
+        "max_terms_count": 20000,
+      },
       "number_of_shards": 3,
       "number_of_replicas": 0,
       "max_ngram_diff": 20,
@@ -32,6 +37,7 @@ export const chcTemplate = {
       "analysis": {
         "analyzer": {
           "default": {
+            "type": "custom",
             "filter": ["lowercase", "norwegian_stop"],
             "tokenizer": "standard"
           },
@@ -67,54 +73,6 @@ export const chcTemplate = {
   "version": 3,
   "_meta": {
     "description": "Settings for CHC search indices containing items and entites."
-  }
-}
-
-export const manifestsTemplate = {
-  "name": "manifests-template",
-  "index_patterns": ["search-manifests-*"],
-  "template": {
-    "settings": {
-      "number_of_shards": "3",
-      "number_of_replicas": "0",
-      "max_ngram_diff": "20",
-      "analysis": {
-        "analyzer": {
-          "default": {
-            "filter": ["lowercase", "norwegian_stop"],
-            "tokenizer": "standard"
-          },
-          "ubb-whitespace": {
-            "type": "custom",
-            "tokenizer": "whitespace",
-            "filter": [
-              "lowercase",
-              "norwegian_stop"
-            ],
-          },
-        },
-        "filter": {
-          "norwegian_stop": {
-            "type": "stop",
-            "stopwords": "_norwegian_"
-          }
-        }
-      }
-    },
-    "mappings": {
-      "_source": {
-        "enabled": true
-      },
-      "properties": mappings.manifests.properties
-    },
-    "aliases": {
-      "search-manifests": {}
-    },
-  },
-  "priority": 500,
-  "version": 3,
-  "_meta": {
-    "description": "my custom"
   }
 }
 
@@ -229,11 +187,3 @@ export const wabTemplate = {
     "description": "my custom"
   }
 }
-
-/* 
-
-Add aliases, but i dont know what it means
-"aliases": {
-  "mydata": { }
-}
-*/

--- a/packages/ingest-cli/src/utils/indexers/utils/bulkIndexData.ts
+++ b/packages/ingest-cli/src/utils/indexers/utils/bulkIndexData.ts
@@ -5,30 +5,56 @@ interface IndexDataResponse {
   errors: string[];
 }
 
+interface BulkIndexResponse {
+  items: Array<{
+    index: {
+      _id: string;
+      error?: any;
+    };
+  }>;
+}
+
 export async function bulkIndexData(data: any, indexName: string, pipeline?: string): Promise<IndexDataResponse | string> {
   if (data.length === 0) return `No data to ingest into ${indexName}`;
 
-  try {
-    // @ts-ignore
-    const response: BulkIndexResponse = await client.bulk({
-      refresh: 'wait_for',
-      body: data,
-      pipeline: pipeline ?? undefined
-    });
+  const maxRetries = 3;
+  let retryCount = 0;
 
-    const errors = response.items.filter((item: any) => item.index.error).map((item: any) => {
-      return `Error indexing item ${item.index._id}: ${JSON.stringify(item.index.error)}`;
-    })
+  while (retryCount < maxRetries) {
+    try {
+      // @ts-ignore
+      const response: BulkIndexResponse = await client.bulk({
+        refresh: 'wait_for',
+        body: data,
+        pipeline: pipeline ?? undefined,
+        timeout: '120s' // Set bulk operation timeout
+      });
 
-    if (errors.length > 0) console.warn(errors)
+      const errors = response.items.filter((item: any) => item.index.error).map((item: any) => {
+        return `Error indexing item ${item.index._id}: ${JSON.stringify(item.index.error)}`;
+      })
 
-    return {
-      count: response.items.length,
-      errors: errors ?? []
+      if (errors.length > 0) console.warn(errors)
+
+      return {
+        count: response.items.length,
+        errors: errors ?? []
+      }
+    }
+    catch (error: any) {
+      retryCount++;
+      const isTimeoutError = error.name === 'TimeoutError' || error.message?.includes('timeout');
+      
+      if (isTimeoutError && retryCount < maxRetries) {
+        console.warn(`Timeout error on attempt ${retryCount}/${maxRetries}, retrying in ${retryCount * 2} seconds...`);
+        await new Promise(resolve => setTimeout(resolve, retryCount * 2000)); // Exponential backoff
+        continue;
+      }
+      
+      console.warn("🚀 ~ file: ingester.js:96 ~ indexData ~ error", error)
+      return error as string;
     }
   }
-  catch (error) {
-    console.warn("🚀 ~ file: ingester.js:96 ~ indexData ~ error", error)
-    return error as string;
-  }
+  
+  return "Max retries exceeded";
 }

--- a/packages/ingest-cli/src/utils/indexers/utils/ensureIndexAndTemplatesReady.ts
+++ b/packages/ingest-cli/src/utils/indexers/utils/ensureIndexAndTemplatesReady.ts
@@ -1,0 +1,59 @@
+import client from '../../../clients/es-client'
+import { logger } from '../../logger'
+import { pipelines } from '../pipelines'
+
+export type EnsureIndexOptions = {
+  index: string
+  putTemplates: () => Promise<any>
+}
+
+function isTemplateError(obj: any): obj is { error: string } {
+  return obj && typeof obj === 'object' && 'error' in obj;
+}
+
+export const putPipelines = async (): Promise<any[]> => {
+  try {
+    const pipelinePromises = Object.values(pipelines).map(pipeline =>
+      client.ingest.putPipeline({
+        id: pipeline.id,
+        body: {
+          description: pipeline.description,
+          version: pipeline.version,
+          processors: (pipeline as any).processors || []
+        }
+      })
+    );
+
+    const results = await Promise.allSettled(pipelinePromises);
+    return results.map(result =>
+      result.status === 'fulfilled'
+        ? { status: 'fulfilled', value: result.value }
+        : { error: String(result.reason) }
+    );
+  } catch (error) {
+    console.error('Error creating pipelines:', error);
+    return [{ error: String(error) }];
+  }
+}
+
+export const ensureIndexAndTemplatesReady = async ({ index, putTemplates }: EnsureIndexOptions) => {
+  // First, create pipelines
+  const pipelineResult = await putPipelines();
+  const hasPipelineError = Array.isArray(pipelineResult) && pipelineResult.some(isTemplateError);
+  if (hasPipelineError) {
+    throw new Error('Elasticsearch pipelines not set up correctly: ' + JSON.stringify(pipelineResult));
+  }
+
+  // Then, set up templates
+  const templateResult = await putTemplates();
+  const hasError = Array.isArray(templateResult) && templateResult.some(isTemplateError);
+  if (hasError) {
+    throw new Error('Elasticsearch templates not set up correctly: ' + JSON.stringify(templateResult));
+  }
+  // Ensure index exists
+  const exists = await client.indices.exists({ index });
+  if (!exists) {
+    logger?.info ? logger.info(`Creating new index ${index}`) : console.log(`Creating new index ${index}`);
+    await client.indices.create({ index });
+  }
+}; 

--- a/packages/ingest-cli/src/utils/indexers/utils/getIndexFromAlias.ts
+++ b/packages/ingest-cli/src/utils/indexers/utils/getIndexFromAlias.ts
@@ -10,19 +10,16 @@ import client from '../../../clients/es-client';
  * @returns The latest index name.
  */
 export const getIndexFromAlias = async (alias: string, index: string, overwrite = false) => {
-  // Finds the current index name in alias and based on the given indicesInAlias object find the latest index.
   let indicesInAlias;
   try {
-    console.log("🔍 Attempting to get alias:", alias);
+    // Attempt to get the alias; if it doesn't exist, that's fine (not an error)
     indicesInAlias = await client.indices.getAlias({ name: alias });
-    console.log("✅ Successfully got alias response");
   } catch (error) {
-    console.log("❌ Error occurred while getting alias:", error);
     if (error instanceof Error && error.message.includes('404')) {
-      // No alias found, return empty object to create first index
-      indicesInAlias = {};
+      // Alias does not exist yet; return the first index name
+      return `${index}_1`;
     } else {
-      // Server error or other issues
+      // Only log unexpected errors
       console.error('Error getting alias:', error);
       if (error instanceof Error) {
         throw new Error(`Failed to get alias "${alias}": ${error.message}`);
@@ -30,8 +27,8 @@ export const getIndexFromAlias = async (alias: string, index: string, overwrite 
       throw new Error(`Failed to get alias "${alias}": Unknown error`);
     }
   }
+
   // Find all indices that match our exact index pattern (base_number)
-  console.log("🚀 ~ getIndexFromAlias ~ indicesInAlias:", indicesInAlias)
   const matchingIndices = Object.keys(indicesInAlias).filter(k => k.startsWith(index));
 
   // Sort indices by their numeric suffix

--- a/packages/ingest-cli/src/utils/ingest-filesets/ingest-filesets.ts
+++ b/packages/ingest-cli/src/utils/ingest-filesets/ingest-filesets.ts
@@ -7,6 +7,8 @@ import { getIndexFromAlias } from '../indexers/utils/getIndexFromAlias'
 import { fetchAndProcessFileset } from './fetch-fileset'
 import { InputItem, fetchFilesetsList } from './fetch-filesets-list'
 import { fetchFilesetsCount } from './fetch-filesets-count'
+import { ensureIndexAndTemplatesReady } from '../indexers/utils/ensureIndexAndTemplatesReady'
+import { putTemplates } from '../tempates/es_templates'
 
 export const resolveItems = async (items: InputItem[]) => {
   try {
@@ -24,6 +26,9 @@ export const ingestFilesets = async (limit = 100, page = 0, overwrite = false) =
 
   // Get the index name
   const useIndex = await getIndexFromAlias(CHC_SEARCH_ALIAS, CHC_INDICIES.file_set, overwrite)
+
+  // Ensure index exists
+  await ensureIndexAndTemplatesReady({ index: useIndex, putTemplates })
 
   // Set initial values
   let status = {

--- a/packages/ingest-cli/src/utils/ingest-groups/ingest-groups.ts
+++ b/packages/ingest-cli/src/utils/ingest-groups/ingest-groups.ts
@@ -7,6 +7,8 @@ import { getIndexFromAlias } from '../indexers/utils/getIndexFromAlias'
 import { fetchAndProcessGroup } from './fetch-group'
 import { InputItem, fetchGroupsList } from './fetch-groups-list'
 import { fetchGroupsCount } from './fetch-groups-count'
+import { ensureIndexAndTemplatesReady } from '../indexers/utils/ensureIndexAndTemplatesReady'
+import { putTemplates } from '../tempates/es_templates'
 
 export const resolveItems = async (items: InputItem[]) => {
   try {
@@ -24,14 +26,8 @@ export const ingestGroups = async (limit = 100, page = 0, overwrite = false) => 
 
   // Get the index name
   const useIndex = await getIndexFromAlias(CHC_SEARCH_ALIAS, CHC_INDICIES.groups, overwrite)
-  // Create index if it doesn't exist
-  const exists = await client.indices.exists({ index: useIndex })
-  if (!exists) {
-    console.log(`Creating new index ${useIndex}`)
-    await client.indices.create({
-      index: useIndex,
-    })
-  }
+  // Ensure index exists
+  await ensureIndexAndTemplatesReady({ index: useIndex, putTemplates })
 
   // Set initial values
   let status = {
@@ -87,7 +83,7 @@ export const ingestGroups = async (limit = 100, page = 0, overwrite = false) => 
     // If no more items to fetch, break the loop
     if (data.length < limit || (status.fetched >= status.totalCount)) {
       console.log(`Finished ingesting in ${pretty(Number(status.runtime))}`);
-      console.log(`Indexed ${status.indexed} filesets of ${status.totalCount}`);
+      console.log(`Indexed ${status.indexed} groups of ${status.totalCount}`);
       if (status.fetched - status.indexed > 0) {
         console.log(`Failed to index ${status.fetched - status.indexed} groups`);
       }
@@ -100,7 +96,7 @@ export const ingestGroups = async (limit = 100, page = 0, overwrite = false) => 
               actions: [
                 {
                   remove: {
-                    index: `${CHC_INDICIES.file_set}_*`,
+                    index: `${CHC_INDICIES.groups}_*`,
                     alias: CHC_SEARCH_ALIAS,
                   },
                 },

--- a/packages/ingest-cli/src/utils/ingest-items/ingest-items.ts
+++ b/packages/ingest-cli/src/utils/ingest-items/ingest-items.ts
@@ -7,6 +7,8 @@ import { getIndexFromAlias } from '../indexers/utils/getIndexFromAlias'
 import { fetchItemsCount } from './fetch-items-count'
 import { fetchItemsList, InputItem } from './fetch-items-list'
 import { fetchAndProcessItem } from './fetch-item'
+import { ensureIndexAndTemplatesReady } from '../indexers/utils/ensureIndexAndTemplatesReady'
+import { putTemplates } from '../tempates/es_templates'
 
 export const resolveItems = async (items: InputItem[]) => {
   try {
@@ -25,6 +27,9 @@ export const ingestItems = async (limit = 100, page = 0, overwrite = false) => {
 
   // Get the index name
   const useIndex = await getIndexFromAlias(CHC_SEARCH_ALIAS, CHC_INDICIES.items, overwrite)
+
+  // Ensure index exists
+  await ensureIndexAndTemplatesReady({ index: useIndex, putTemplates })
 
   // Set initial values
   let status = {

--- a/packages/ingest-cli/src/utils/ingest-people/fetch-people-count.ts
+++ b/packages/ingest-cli/src/utils/ingest-people/fetch-people-count.ts
@@ -15,6 +15,7 @@ const query = `
           VALUES ?types { foaf:Person ubbont:Cataloguer }
           ?uri rdf:type ?types ;
             dct:identifier ?id .
+          FILTER(STRENDS(STR(?uri), LCASE(?id))) .
         }
     }
   }

--- a/packages/ingest-cli/src/utils/ingest-sets/fetch-set.ts
+++ b/packages/ingest-cli/src/utils/ingest-sets/fetch-set.ts
@@ -1,0 +1,196 @@
+import { endpointUrl } from '@/clients/sparql-chc-client';
+import { SPARQL_PREFIXES } from '../../constants';
+import { JsonLdDocument, ContextDefinition } from 'jsonld';
+import ubbontContext from 'jsonld-contexts/src/ubbontContext';
+import { sqb, useFrame } from 'utils';
+import { observeClient } from '@/clients/es-client';
+import { ZodSetSchema } from 'types';
+import { constructDigitalIntegration } from '../mappers/la/shared/constructDigitalIntegration';
+import { constructIdentifiers } from '../mappers/la/shared/constructIdentifiers';
+import { constructAboutness } from '../mappers/la/shared/constructAboutness';
+import { constructAssertions } from '../mappers/la/shared/constructAssertions';
+import { constructSubjectTo } from '../mappers/la/shared/constructSubjectTo';
+import { constructCoreMetadata } from '../mappers/la/set/constructCoreMetadata';
+import { getTimeSpan } from '../mappers/la/shared/constructTimeSpan';
+import { TBaseMetadata } from '../ingest-items/fetch-item';
+import { removeStringsFromArray } from '../mappers/la/removeStringsFromArray';
+import { env } from '@/env';
+import omitEmptyEs from 'omit-empty-es';
+import { constructHierarchy } from '../mappers/la/set/constructHierarchy';
+import { constructCreation } from '../mappers/la/set/constructCreation';
+
+export type UbbontItem = {
+  [key: string]: any;
+}
+
+const query = `
+  ${SPARQL_PREFIXES}
+  CONSTRUCT { 
+    ?uri a la:Set ;
+      ?p ?o ;
+      crm:P2_has_type ?type ;
+      rdfs:label ?label ;
+      foaf:homepage ?homepage .
+    ?o a ?oClass ;
+      ?p2 ?o2 ;
+      dct:identifier ?oIdentifier ;
+      rdfs:label ?oLabel ;
+      ubbont:hasURI ?hasURI .
+  } WHERE { 
+    VALUES ?id {"%id"}
+    VALUES ?types { bibo:Collection }
+    ?uri dct:identifier ?id ;
+      rdf:type ?types ;
+      ?p ?o ;
+      a ?class .
+    OPTIONAL {?uri dct:title ?title } .
+    OPTIONAL {?uri foaf:name ?name } .
+    OPTIONAL {?uri skos:prefLabel ?prefLabel } .
+    OPTIONAL {?uri rdfs:label ?rdfsLabel } .
+    BIND (COALESCE(?title,?name,?prefLabel,?rdfsLabel) AS ?label) .  
+    OPTIONAL { 
+      ?o a ?oClass ;
+      dct:identifier ?oIdentifier ;
+      OPTIONAL { ?o foaf:gender ?oGender } .
+      OPTIONAL { ?o (dct:title|foaf:name|skos:prefLabel|rdfs:label) ?oLabel } . 
+      OPTIONAL { ?o ubbont:hasURI ?hasURI } .
+      FILTER(?oClass != rdfs:Class) .
+    }
+    FILTER(STRENDS(STR(?uri), LCASE(?id))) .
+    FILTER(?o != ?uri) .
+    BIND(REPLACE(STR(?class), ".+[/#]([^/#]+)$", "$1") as ?type) .
+    BIND(iri(REPLACE(str(?uri), "http://data.ub.uib.no","https://marcus.uib.no","i")) as ?homepage) .
+    FILTER(?p NOT IN (rdf:type, foaf:made, dct:hasPart, ubbont:receivedFrom, ubbont:cataloguer, org:hasSubOrganization, skos:prefLabel,ubbont:isSubjectOf, org:hasMember, ubbont:formerOwnerOf,  ubbont:originalCreatorOf, ubbont:commissioned, ubbont:ownedBy, skos:broader, ubbont:isRightsHolderOf, skos:narrower, ubbont:reproduced, ubbont:internalNote, ubbont:showWeb, ubbont:clause, ubbont:hasRepresentation, ubbont:hasThumbnail, dct:relation, dc:relation, dct:isReferencedBy, ubbont:hasTranscription, skos:inScheme, ubbont:published))
+  }
+`
+
+export const fetchSet = async (id: string): Promise<UbbontItem> => {
+  try {
+    const response = await fetch(`${endpointUrl}?query=${encodeURIComponent(sqb(query, { id }))}&output=json`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch set: ${response.statusText}`);
+    }
+    const data = await response.json();
+    if (!data || Object.keys(data).length === 0) {
+      throw new Error(`No data found for id: ${id}`);
+    }
+    return data;
+  } catch (error) {
+    throw new Error(`Error fetching set ${id}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+};
+
+
+export const frameSet = async (data: UbbontItem, id: string): Promise<JsonLdDocument> => {
+  if (!data || Object.keys(data).length === 0) {
+    throw new Error('Cannot frame empty data');
+  }
+
+  // Find the matching item in the graph
+  const matchingItem = (data['@graph'] ?? [data]).find((item: any) => item['dct:identifier'] === id);
+  if (!matchingItem) {
+    throw new Error('Group not found in graph');
+  }
+
+  const url = matchingItem['@id'].replace('j.0:', 'http://data.ub.uib.no/');
+
+  try {
+    const framed: JsonLdDocument = await useFrame({
+      data: data,
+      context: ubbontContext as ContextDefinition,
+      type: 'Set',
+      id: url
+    });
+    if (!framed) {
+      throw new Error('Framing resulted in empty document');
+    }
+    return framed;
+  } catch (error) {
+    throw new Error(`Error framing group: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+export const mapSetToLinkedArt = async (data: UbbontItem): Promise<JsonLdDocument> => {
+  if (!data || Object.keys(data).length === 0) {
+    throw new Error('Cannot map empty data to LinkedArt');
+  }
+  try {
+    let dto: any = data;
+    const DEFAULT_MODIFIED_DATE = "2020-01-01T00:00:00";
+
+    // CLEANUP SECTION
+    // We assume all @none language tags are really norwegian
+    dto = JSON.parse(JSON.stringify(dto).replaceAll('"@none":', '"no":').replaceAll('"none":', '"no":'));
+    // Removes non-object items from the specified properties of the input dto array.
+    dto = removeStringsFromArray(dto);
+
+    // Remove the inline context and add the url to the context
+    dto['@context'] = [`${env.API_URL}/ns/ubbont/context.json`];
+
+    dto._modified = Array.isArray(dto._modified) ? dto._modified.sort((a: string, b: string) => new Date(a).getTime() - new Date(b).getTime())[0] : dto._modified ?? DEFAULT_MODIFIED_DATE;
+    // @TODO: Remove this when we have dct:modified on all items in the dataset
+    dto._modified = dto._modified ?? DEFAULT_MODIFIED_DATE;
+    // _available can be an array of dates, we need to pick the "oldest one"
+    dto._available = Array.isArray(dto._available) ? dto._available.sort((a: string, b: string) => new Date(a).getTime() - new Date(b).getTime())[0] : dto._available ?? DEFAULT_MODIFIED_DATE;
+    dto = omitEmptyEs(dto);
+
+    const base: TBaseMetadata = {
+      identifier: dto.identifier,
+      context: ['https://linked.art/ns/v1/linked-art.json', 'https://api.ub.uib.no/ns/ubbont/context.json'],
+      newId: `${dto.uuid ?? dto.identifier}`,
+      originalId: dto.id,
+      productionTimeSpan: getTimeSpan(dto.created, dto.madeAfter, dto.madeBefore),
+      _label: dto._label,
+    };
+
+    // Construct LinkedArt
+    dto = constructCoreMetadata(base, dto);
+    dto = constructIdentifiers(dto);
+    dto = constructHierarchy(dto);
+    dto = constructCreation(dto);
+    dto = constructDigitalIntegration(dto);
+    dto = await constructAboutness(dto);
+    dto = constructAssertions(base, dto);
+    dto = await constructSubjectTo(base, dto);
+
+    const parsed = ZodSetSchema.safeParse(dto);
+    if (parsed.success === false) {
+      console.log(base.identifier);
+      console.log(dto);
+      console.log(parsed.error.issues);
+      await observeClient.index({
+        index: 'logs-chc',
+        body: {
+          '@timestamp': new Date(),
+          message: `id: ${base.identifier}, issues: ${JSON.stringify(parsed.error.issues)}`
+        }
+      });
+      // You might want to throw an error here depending on your requirements
+      // throw new Error(`Validation failed for item ${base.identifier}`);
+    }
+    return dto;
+  } catch (error) {
+    throw new Error(`Error mapping set to LinkedArt: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
+export const fetchAndProcessSet = async (id: string): Promise<JsonLdDocument | null> => {
+  try {
+    const set = await fetchSet(id);
+    const framed = await frameSet(set, id);
+    const linkedArt = await mapSetToLinkedArt(framed);
+    return linkedArt;
+  } catch (error) {
+    // Log the error
+    console.error(`Error processing set ${id}:`, error);
+    await observeClient.index({
+      index: 'logs-chc',
+      body: {
+        '@timestamp': new Date(),
+        message: `Error processing set ${id}: ${error instanceof Error ? error.message : 'Unknown error'}`
+      }
+    });
+    // Return null instead of throwing, or throw depending on your requirements
+    return null;
+  }
+}

--- a/packages/ingest-cli/src/utils/ingest-sets/fetch-sets-count.ts
+++ b/packages/ingest-cli/src/utils/ingest-sets/fetch-sets-count.ts
@@ -1,0 +1,28 @@
+import { env } from '@/env';
+
+const query = `
+  PREFIX bibo: <http://purl.org/ontology/bibo/>
+  PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+  PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+  PREFIX dct: <http://purl.org/dc/terms/>
+  PREFIX ubbont: <http://data.ub.uib.no/ontology/>
+  PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+  PREFIX dbo: <http://dbpedia.org/ontology/>
+
+  SELECT (count(?uri) as ?count) WHERE { 
+    SERVICE <cache:> { 
+      SELECT ?uri WHERE 
+        { 
+          VALUES ?types { bibo:Collection }
+          ?uri rdf:type ?types ;
+            dct:identifier ?id .
+        }
+    }
+  }
+`
+
+export const fetchSetsCount = async (): Promise<number> => {
+  const response = await fetch(`${env.SPARQL_CHC_ENDPOINT}?query=${encodeURIComponent(query)}&output=json`)
+  const data = await response.json();
+  return data.results.bindings[0].count.value;
+};

--- a/packages/ingest-cli/src/utils/ingest-sets/fetch-sets-list.ts
+++ b/packages/ingest-cli/src/utils/ingest-sets/fetch-sets-list.ts
@@ -1,0 +1,40 @@
+import { env } from '@/env';
+import { sqb } from 'utils';
+
+export type InputItem = {
+  id: string
+  identifier: string
+}
+
+const query = `
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ore: <http://www.openarchives.org/ore/terms/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ubbont: <http://data.ub.uib.no/ontology/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX bibo: <http://purl.org/ontology/bibo/>
+
+JSON {
+  "id": ?uri,
+  "identifier": ?id 
+} WHERE { 
+SERVICE <cache:> { 
+  SELECT ?uri ?id WHERE 
+    { 
+      VALUES ?types { bibo:Collection }
+      ?uri rdf:type ?types ;
+      dct:identifier ?id .
+      FILTER(STRENDS(STR(?uri), LCASE(?id))) .
+    }
+    ORDER BY ?id
+    OFFSET %page
+    LIMIT %limit
+  } 
+}`
+
+export const fetchSetsList = async (page: number, limit: number): Promise<InputItem[]> => {
+  const response = await fetch(`${env.SPARQL_CHC_ENDPOINT}?query=${encodeURIComponent(sqb(query, { page, limit }))}&output=json`)
+  return response.json();
+};

--- a/packages/ingest-cli/src/utils/ingest-sets/ingest-set.ts
+++ b/packages/ingest-cli/src/utils/ingest-sets/ingest-set.ts
@@ -1,0 +1,64 @@
+import client, { observeClient } from '../../clients/es-client'
+import { CHC_SEARCH_ALIAS, CHC_INDICIES } from '../../constants'
+import { HTTPException } from 'hono/http-exception'
+import { fetchAndProcessSet } from './fetch-set'
+
+export const ingestSet = async (id: string) => {
+  // Finds the current index name in alias and based on the given indicesInAlias object find the latest index.
+  const indicesInAlias = await client.indices.getAlias({ name: CHC_SEARCH_ALIAS })
+  const currentIndex = Object.keys(indicesInAlias).find(k => k.startsWith(CHC_INDICIES.sets))
+
+  if (!currentIndex) {
+    throw new Error(`No index found for ${CHC_INDICIES.sets}`)
+  }
+
+  const response = await fetchAndProcessSet(id)
+
+  try {
+    // Search for documents with matching id field
+    const searchResult = await client.search({
+      index: currentIndex,
+      body: {
+        query: {
+          match: { "id.keyword": id }
+        },
+        size: 2  // We only need to know if there's more than one
+      }
+    });
+
+    // Needed to check the number of hits, as the value can be a number or an object. Typescript doesn't like this.
+    let numberOfHits = 0
+    if (typeof searchResult.hits.total === 'object') {
+      numberOfHits = searchResult.hits.total.value
+    } else {
+      numberOfHits = searchResult.hits.total ?? 0
+    }
+
+
+    if (numberOfHits > 1) {
+      // Multiple documents found - this is an error condition
+      console.error(`Multiple documents found with id ${id}`);
+      throw new HTTPException(409, { message: `Data integrity error: Multiple documents found with id ${id}` });
+    }
+
+    let operation = 'Inserted';
+    let existingDocId;
+    if (numberOfHits === 1) {
+      // Document exists, we'll replace it
+      operation = 'Replaced';
+      existingDocId = searchResult.hits.hits[0]._id;
+    }
+
+    // Use the index API to replace the document or create a new one
+    await client.index({
+      index: currentIndex,
+      id: existingDocId,
+      body: response,
+      pipeline: 'chc-pipeline'
+    });
+
+    console.log({ status: 'ok', message: `${operation} document with id ${id}` });
+  } catch (err) {
+    console.error('Error replacing/inserting document:', err);
+  }
+}

--- a/packages/ingest-cli/src/utils/ingest-sets/ingest-sets.ts
+++ b/packages/ingest-cli/src/utils/ingest-sets/ingest-sets.ts
@@ -1,0 +1,131 @@
+import client from '../../clients/es-client'
+import { CHC_SEARCH_ALIAS, CHC_INDICIES } from '../../constants'
+import { bulkIndexData } from '../indexers/utils/bulkIndexData'
+import { flatMapDataForBulkIndexing } from '../indexers/utils/flatMapDataForBulkIndexing'
+import pretty from 'pretty-time'
+import { getIndexFromAlias } from '../indexers/utils/getIndexFromAlias'
+import { fetchAndProcessSet } from './fetch-set'
+import { InputItem, fetchSetsList } from './fetch-sets-list'
+import { fetchSetsCount } from './fetch-sets-count'
+import { putTemplates } from '../tempates/es_templates'
+import { logger } from '../logger'
+import { ensureIndexAndTemplatesReady } from '../indexers/utils/ensureIndexAndTemplatesReady'
+
+export const resolveItems = async (items: InputItem[]) => {
+  try {
+    const promises = items
+      .map(item => fetchAndProcessSet(item.identifier))
+      .filter(Boolean)
+    return await Promise.all(promises)
+  } catch (error) {
+    console.error('Error resolving items:', error)
+  }
+}
+
+export const ingestSets = async (limit = 100, page = 0, overwrite = false) => {
+  const count = await fetchSetsCount()
+
+  // Get the index name
+  const useIndex = await getIndexFromAlias(CHC_SEARCH_ALIAS, CHC_INDICIES.sets, overwrite)
+  // Ensure index and Elasticsearch are ready
+  await ensureIndexAndTemplatesReady({ index: useIndex, putTemplates })
+
+  // Set initial values
+  let status = {
+    currentPage: page,
+    totalCount: count,
+    fetched: page * limit,    // Assume all previous pages were fetched
+    indexed: page * limit,    // Assume all previous pages were indexed
+    runtime: BigInt(0),
+  }
+  console.log("🚀 ~ ingestSets ~ status:", status)
+
+  console.log(`Starting ingester using the index ${useIndex} (with ${CHC_SEARCH_ALIAS} as alias)`)
+
+  while (true) {
+    console.log('Fetching page', status.currentPage);
+    // Fetch ids
+    const t0 = process.hrtime.bigint();
+    const data = await fetchSetsList(status.currentPage * limit, limit);
+    const t1 = process.hrtime.bigint();
+    console.log('├── Fetched', data.length, 'ids in', pretty(Number(t1) - Number(t0)));
+
+    status.fetched += data.length;
+
+    try {
+      // Resolve ids
+      const t2 = process.hrtime.bigint();
+      const resolved = await resolveItems(data);
+      const t3 = process.hrtime.bigint();
+      console.log('├── Resolved', resolved?.length ?? 0, 'items in', pretty(Number(t3) - Number(t2)));
+
+      // Identify missing sets
+      /* const dataIdentifiers = data.map(item => item.id.split('/').pop());
+      const resolvedIdentifiers = (resolved ?? []).map(item => item?.id).filter(Boolean);
+      const missingIdentifiers = dataIdentifiers.filter(id => !resolvedIdentifiers.includes(id));
+      if (missingIdentifiers.length > 0) {
+        console.warn('⚠️ Missing sets (not resolved):', missingIdentifiers);
+      } */
+
+      // Prepare bulk payload
+      const t6 = process.hrtime.bigint();
+      const bulkPayload = flatMapDataForBulkIndexing(resolved, useIndex);
+      const t7 = process.hrtime.bigint();
+      console.log('├── Prepared the payload for bulk indexing.', bulkPayload.length / 2, 'items in', pretty(Number(t7) - Number(t6)));
+
+      // Index data
+      const t8 = process.hrtime.bigint();
+      const indexStatus: any = await bulkIndexData(bulkPayload, useIndex) ?? 0;
+      const t9 = process.hrtime.bigint();
+      status.indexed += indexStatus.count;
+      console.log('└── Indexed', indexStatus.count, '.', ((status.indexed * 100) / status.totalCount).toFixed(3), '% of', status.totalCount, 'in', pretty(Number(t9) - Number(t8)));
+
+      // Update status
+      status.currentPage += 1;
+      status.runtime += process.hrtime.bigint() - t0;
+
+    } catch (iterationError) {
+      console.log('Error in loop iteration:', iterationError);
+      return
+    }
+
+    // If no more items to fetch, break the loop
+    if (data.length < limit || (status.fetched >= status.totalCount)) {
+      console.log(`Finished ingesting in ${pretty(Number(status.runtime))}`);
+      console.log(`Indexed ${status.indexed} sets of ${status.totalCount}`);
+      if (status.fetched - status.indexed > 0) {
+        console.log(`Failed to index ${status.fetched - status.indexed} sets`);
+      }
+
+      // Update aliases
+      if (!overwrite) {
+        try {
+          await client.indices.updateAliases({
+            body: {
+              actions: [
+                {
+                  remove: {
+                    index: `${CHC_INDICIES.sets}_*`,
+                    alias: CHC_SEARCH_ALIAS,
+                  },
+                },
+                {
+                  add: {
+                    index: useIndex,
+                    alias: CHC_SEARCH_ALIAS,
+                  },
+                },
+              ],
+            },
+          });
+          console.log('Aliases updated');
+        } catch (error) {
+          console.log('Error updating aliases:', error);
+          return;
+        }
+      }
+
+      return
+    }
+  }
+}

--- a/packages/ingest-cli/src/utils/mappers/la/set/constructCoreMetadata.ts
+++ b/packages/ingest-cli/src/utils/mappers/la/set/constructCoreMetadata.ts
@@ -1,0 +1,54 @@
+import { TBaseMetadata } from '../../../ingest-items/fetch-item';
+import omitEmptyEs from 'omit-empty-es';
+import { coalesceLabel } from 'utils';
+import { aatArchivalGroupingType, aatArchivalSubGroupingType } from '../staticMapping';
+
+export const constructCoreMetadata = (base: TBaseMetadata, data: any) => {
+  const {
+    context,
+    newId,
+    _label,
+  } = base;
+
+  const {
+    hasType,
+    email,
+    isPartOf
+  } = data;
+
+  if (
+    !newId &&
+    !_label &&
+    !context &&
+    !email
+  ) return data;
+
+  delete data.id
+  delete data._label
+  delete data["@context"]
+  delete data.img
+  delete data.lat
+  delete data.long
+  delete data.email
+  delete data.owner
+  delete data.based_near
+  delete data.pages
+  delete data.featured
+
+  // We type the set as an archival grouping or sub grouping based on the isPartOf property
+  const classified_as = [
+    isPartOf ? aatArchivalSubGroupingType : aatArchivalGroupingType
+  ];
+
+
+  return omitEmptyEs({
+    "@context": context,
+    id: newId,
+    type: "Set",
+    _label: coalesceLabel(_label) ?? `${hasType} with identifier ${newId}`,
+    classified_as: [
+      ...classified_as
+    ],
+    ...data
+  });
+}

--- a/packages/ingest-cli/src/utils/mappers/la/set/constructCreation.ts
+++ b/packages/ingest-cli/src/utils/mappers/la/set/constructCreation.ts
@@ -1,0 +1,40 @@
+import { checkIntervalValidity } from 'utils';
+import { getTimeSpan } from '../shared/constructTimeSpan';
+import { env } from '@/env';
+
+export const constructCreation = (data: any) => {
+  const {
+    maker,
+    madeAfter,
+    madeBefore,
+  } = data;
+
+  if (!maker && !madeAfter && !madeBefore) return data;
+
+  delete data.maker;
+  delete data.madeAfter;
+  delete data.madeBefore;
+
+  let start = madeAfter;
+  let end = madeBefore;
+
+  if (start && end) {
+    [start, end] = checkIntervalValidity(start, end);
+  }
+
+  const createdTimeSpan = getTimeSpan(start, end, null);
+
+  return {
+    ...data,
+    created_by: {
+      type: "Creation",
+      _label: `Creation of collection by ${maker.map((m: any) => m.name).join(', ')}`,
+      timespan: createdTimeSpan,
+      created_by: maker.map((m: any) => ({
+        type: "Person",
+        id: `${env.PROD_URL}/person/${m.identifier}`,
+        _label: m.name,
+      })),
+    },
+  };
+};

--- a/packages/ingest-cli/src/utils/mappers/la/set/constructHierarchy.ts
+++ b/packages/ingest-cli/src/utils/mappers/la/set/constructHierarchy.ts
@@ -1,0 +1,23 @@
+import { env } from '@/env';
+import { coalesceLabel } from 'utils';
+
+export const constructHierarchy = (data: any) => {
+  const {
+    isPartOf
+  } = data;
+
+  if (!isPartOf) return data;
+
+  delete data.isPartOf
+
+  return {
+    ...data,
+    member_of: isPartOf.map((o: any) => {
+      return {
+        id: `${env.PROD_URL}/sets/${o.identifier}`,
+        type: 'Set',
+        _label: coalesceLabel(o._label),
+      }
+    })
+  }
+}

--- a/packages/ingest-cli/src/utils/mappers/la/shared/constructDigitalIntegration.ts
+++ b/packages/ingest-cli/src/utils/mappers/la/shared/constructDigitalIntegration.ts
@@ -71,7 +71,7 @@ export const constructDigitalIntegration = (data: any) => {
   }
 
   if (logoArray.length > 0) {
-    logoArray = logoArray.map((logo: string) => {
+    logoArray = logoArray.map((logo: string | { id: string }) => {
       return {
         type: 'VisualItem',
         digitally_shown_by: [
@@ -83,7 +83,7 @@ export const constructDigitalIntegration = (data: any) => {
               aatLogoType,
             ],
             access_point: [{
-              id: logo,
+              id: typeof logo === 'string' ? logo : logo.id,
               type: 'DigitalObject',
             }]
           }

--- a/packages/ingest-cli/src/utils/mappers/la/staticMapping.ts
+++ b/packages/ingest-cli/src/utils/mappers/la/staticMapping.ts
@@ -338,6 +338,28 @@ export const aatSiblingsType = {
   _label: "Siblings"
 }
 
+export const aatSortValueType = {
+  id: "http://vocab.getty.edu/aat/300456575",
+  type: "Type",
+  _label: "Sort Value"
+}
+
+export const aatArchivalGroupingType = {
+  id: "http://vocab.getty.edu/aat/300404022",
+  type: "Type",
+  _label: "Archival Grouping"
+}
+
+export const aatArchivalSubGroupingType = {
+  id: "http://vocab.getty.edu/aat/300404023",
+  type: "Type",
+  _label: "Archival SubGrouping"
+}
+
+/**
+ * UBB Types
+ */
+
 export const ubbChildrenType = {
   id: "https://api.ub.uib.no/concept/d8c2ea50-2e30-4616-8a5e-9d1173b5b306",
   type: "Type",

--- a/packages/jsonld-contexts/src/ubbontContext.ts
+++ b/packages/jsonld-contexts/src/ubbontContext.ts
@@ -32,6 +32,7 @@ const ubbontContext = {
     "locah": "http://data.archiveshub.ac.uk/def/",
     "lexvo": "http://lexvo.org/ontology#",
     "cc": "http://creativecommons.org/ns#",
+    "la": "https://linked.art/ns/terms/",
     "id": "@id",
     "type": "@type",
     "none": "@none",
@@ -62,6 +63,9 @@ const ubbontContext = {
     },
     "Production": {
       "@id": "crm:E12_Production"
+    },
+    "Set": {
+      "@id": "la:Set"
     },
     "producedBy": {
       "@id": "crm:P108i_was_produced_by",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,3 @@
 export type { CollectionSchema, DigitalObjectSchema, EventSchema, GroupSchema, HumanMadeObjectSchema, Person as PersonSchema, PlaceSchema, ProvenanceActivitySchema, TextSchema, VisualContentSchema } from './la/types/linked_art.d'
-export { groupSchemaSchema as ZodGroupSchema, humanMadeObjectSchemaSchema as ZodHumanMadeObjectSchema, personSchema as ZodPersonSchema } from './la/zod/linked_art'
+export { groupSchemaSchema as ZodGroupSchema, humanMadeObjectSchemaSchema as ZodHumanMadeObjectSchema, personSchema as ZodPersonSchema, collectionSchemaSchema as ZodSetSchema } from './la/zod/linked_art'
 


### PR DESCRIPTION
- Introduced a new route for handling sets, allowing retrieval by ID.
- Implemented SPARQL query for fetching set data and related items.
- Added utility functions for constructing IIIF Collection objects from sets.
- Included necessary schemas for request validation and response formatting.
- Updated main application entry to include the new sets route.